### PR TITLE
Updated embassy_hal dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,8 @@ cortex-m = { version = "0.7", features = [ "critical-section-single-core",], def
 cortex-m-rt = { version = "0.7" }
 embedded-hal = { version = "1.0.0" }
 embedded-time = { version = "0.12.1" }
-embassy-time-driver = { git = "https://github.com/embassy-rs/embassy.git", rev = "68c8238", optional = true }
-embassy-time = { git = "https://github.com/embassy-rs/embassy.git", rev = "68c8238" }
+embassy-time-driver = { git = "https://github.com/embassy-rs/embassy.git", rev = "0e82b7d", optional = true }
+embassy-time = { git = "https://github.com/embassy-rs/embassy.git", rev = "0e82b7d" }
 
 [features]
 default = ["embassy_time", "iic0", "port4"]

--- a/src/time_driver.rs
+++ b/src/time_driver.rs
@@ -94,17 +94,8 @@ impl Driver for RenesasDriver {
         })
     }
 
-    unsafe fn allocate_alarm(&self) -> Option<embassy_time_driver::AlarmHandle> {
-        None
-    }
-
-    fn set_alarm_callback(&self, _alarm: embassy_time_driver::AlarmHandle, _callback: fn(*mut ()), _ctx: *mut ()) {
-        // TODO: add alarms later
-    }
-
-    fn set_alarm(&self, _alarm: embassy_time_driver::AlarmHandle, _timestamp: u64) -> bool {
-        // TODO: add alarms later
-        return false;
+    fn schedule_wake(&self, at: u64, waker: &core::task::Waker) {
+        todo!()
     }
 }
 


### PR DESCRIPTION
This is necessitated by [PR #3275 in the Pictorus repo](https://github.com/Pictorus-Labs/pictorus/pull/3275). The embassy_hal dependency had to be moved up to a more recent git commit to enable support for new targets. This PR mostly just updates the commit hashes but some minor changes had to be made to the embassy_time_driver implementation to match the API changes from the last year or so.